### PR TITLE
Update tests to pass on linux

### DIFF
--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -3,30 +3,30 @@
  Summary:
     Contains file access functions and classes.
 
-    This module contains convenience functions and classes for reading and 
+    This module contains convenience functions and classes for reading and
     writing files and launching different types of File dialogue.
-    
+
     Some of the functionality needed in this class is provided by the PyQt
     framework. When this module is loaded it tries to import the PyQt module.
     If it fails it sets a HAS_QT flag to False.
-    
+
     Before any attempts to use the PyQt functions are made the HAS_QT flag
     is checked. If it's false the function will react.
 
- Author:  
+ Author:
      Duncan Runnacles
-     
-  Created:  
+
+  Created:
      01 Apr 2016
- 
- Copyright:  
+
+ Copyright:
      Duncan Runnacles 2016
 
  TODO: This module, like a lot of other probably, needs reviewing for how
          'Pythonic' t is. There are a lot of places where generators,
          comprehensions, maps, etc should be used to speed things up and make
          them a bit clearer.
-         
+
          More importantly there are a lot of places using '==' compare that
          should be using 'in' etc. This could cause bugs and must be fixed
          soon.
@@ -47,7 +47,7 @@ from ship.utils import utilfunctions as uf
 
 
 HAS_QT = True
-"""If Qt is not installed on the machine running the library we can't use any 
+"""If Qt is not installed on the machine running the library we can't use any
 of the GUI related code, such as file dialogs. This flag informs the code in
 the module about the load status.
 """
@@ -132,7 +132,7 @@ def directoryFileNames(path):
         List - filenames in directory.
 
     Raises:
-        IOError: If there's a problem with the read/write or the directory 
+        IOError: If there's a problem with the read/write or the directory
             doesn't exist
         TypeError: if string not given for file_path.
     """
@@ -193,7 +193,7 @@ def getOpenFileDialog(path='', types='All (*.*)', multi_file=True):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
         multi_file=True(bool): If False user can only select a single file.
 
     Returns:
@@ -228,7 +228,7 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
 
     Returns:
         Str containing path is successful or False if not.
@@ -252,9 +252,9 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
 
 """
-###############################                                                                         
-  Path Functions and classes                                                 
-###############################                                                                         
+###############################
+  Path Functions and classes
+###############################
 """
 
 
@@ -262,7 +262,7 @@ def pathExists(path):
     """Test whether a path exists.
 
     Args:
-        path (str):  the path to test. 
+        path (str):  the path to test.
 
     Returns:
         True if the path exists or False if it doesn't.
@@ -295,30 +295,9 @@ def setFinalFolder(path, folder_name):
     Returns:
         str containing the updated path.
     """
-    # Normalise the path so that we don't get any funny behaviour
-    norm_path = os.path.normpath(path)
-
-    # Get the drive letter
-    drive_letter = os.path.splitdrive(norm_path)[0]
-
-    # Separate out the different folders.
-    # If it's an absolute path then we need to deal with the usual drive
-    # letter problems (doesn't join it back with a slash.
-    plist = norm_path.split(os.sep)
-    if drive_letter:
-        all_but_final_folder = plist[1:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-        all_but_final_folder = plist[0] + os.path.sep + all_but_final_folder
-        all_but_final_folder = os.path.normpath(all_but_final_folder)
-
-    # Otherwise just remove the final folder so that we can replace it
-    # with the new one.
-    else:
-        all_but_final_folder = plist[:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-
-    # Add the new folder name to the end
-    return os.path.join(all_but_final_folder, folder_name)
+    opth = os.path
+    path = opth.normpath(path)
+    return opth.join(opth.dirname(path), folder_name)
 
 
 def getFileName(in_path, with_extension=False):
@@ -326,11 +305,11 @@ def getFileName(in_path, with_extension=False):
 
     Args:
         in_path (str): the file path to extract the filename from.
-        with_extension=False (Bool): flag denoting whether to return 
+        with_extension=False (Bool): flag denoting whether to return
             the filename with or without the extension.
 
     Returns:
-        Str - file name, with or without the extension appended or a 
+        Str - file name, with or without the extension appended or a
              blank string if there is no file name in the path.
     """
     filename = os.path.basename(in_path)
@@ -348,15 +327,15 @@ def getFileName(in_path, with_extension=False):
 def directory(in_path):
     """Get the directory component of the given path.
 
-    Checks the given path to see if it has a file or not. 
+    Checks the given path to see if it has a file or not.
 
-    If there is no file component in the path it will return the path as-is. 
+    If there is no file component in the path it will return the path as-is.
 
-    If there is no directory component in the file it will return a 
+    If there is no directory component in the file it will return a
     blank string.
 
     Args:
-        in_path (str): the path to extract the directory from.   
+        in_path (str): the path to extract the directory from.
 
     Returns:
         Str - directory component of the given file path.
@@ -396,11 +375,11 @@ class PathHolder(object):
         """Constructor.
 
         Args:
-            path (str): the path to the file that this object holds the meta 
+            path (str): the path to the file that this object holds the meta
                 data for.
-            root (str): Optional - the path to the directory that is the root 
-                of this file. Most tuflow files are referenced relative to the 
-                file that they are called from. The root will allow for an 
+            root (str): Optional - the path to the directory that is the root
+                of this file. Most tuflow files are referenced relative to the
+                file that they are called from. The root will allow for an
                 absolute path to be created from the relative path.
         """
 #         if not isinstance(path, basestring):
@@ -442,13 +421,13 @@ class PathHolder(object):
     def finalFolder(self):
         """Get the last folder in the path.
 
-        If the relative_root variable is set it will be taken from that. 
-        Otherwise if it is not and the root variable is set it will be taken 
+        If the relative_root variable is set it will be taken from that.
+        Otherwise if it is not and the root variable is set it will be taken
         from that. If nether are set it will return False.
 
         Returns:
-            tuple - the first part of the directory path and the final 
-                folder in the directory path for this file, or False if the 
+            tuple - the first part of the directory path and the final
+                folder in the directory path for this file, or False if the
                 variable has not been set.
         """
         final_folder = False
@@ -480,8 +459,8 @@ class PathHolder(object):
         is no way of knowing what the absolute path will be.
 
         Args:
-            filename: Optional - if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename: Optional - if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -556,14 +535,14 @@ class PathHolder(object):
         """Returns the full relative root with filename for this object.
 
 
-        If a relative root was given to the constructor or set later this will 
+        If a relative root was given to the constructor or set later this will
         return it, otherwise it will return False.
 
         Args:
             with_extension=True (bool): append the extension to the end of the
                 path if True.
-            filename=None (str): if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename=None (str): if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -604,26 +583,26 @@ class PathHolder(object):
         """Sets the absolute path of this object.
 
         Takes an absolute path and set the file variables in this object with
-        it. 
+        it.
 
         Note:
-            This function WILL NOT check that the path exists. If the path used 
-            to call this function must exist it is the responsibility of the 
+            This function WILL NOT check that the path exists. If the path used
+            to call this function must exist it is the responsibility of the
             caller to check this.
 
         keep_relative_root variable information:
 
-        If a relative root is not set to None it will be included in any path 
-        that is returned by this object. i.e. when an absolute path is 
-        returned by this object it will return: 
+        If a relative root is not set to None it will be included in any path
+        that is returned by this object. i.e. when an absolute path is
+        returned by this object it will return:
 
         path + relativepath + filename + extension
 
         Args:
             absolute_path (str): the new absolute path to use to set the file
                 variables in this object.
-            keep_relative_root=False (Bool): if a relative root exists for 
-                this object it will be set to None unless this variable is 
+            keep_relative_root=False (Bool): if a relative root exists for
+                this object it will be set to None unless this variable is
                 set to True.         """
         absolute_path = absolute_path.strip()
         self.root, filename = os.path.split(absolute_path)
@@ -645,10 +624,10 @@ class PathHolder(object):
 
         Args:
             filename (str): the new filename to set.
-            has_extension=False (Bool): whether the filename has a file 
-                extension or not. This should be set to True if an extension 
-                exists. Otherwise the filename will be corrupted. 
-            keep_extension: if the caller want to keep the extension on the 
+            has_extension=False (Bool): whether the filename has a file
+                extension or not. This should be set to True if an extension
+                exists. Otherwise the filename will be corrupted.
+            keep_extension: if the caller want to keep the extension on the
                given filename this should be True. Otherwise the file extension
                on the new filename will be discarded.
         """
@@ -668,7 +647,7 @@ class PathHolder(object):
         """Test whether the path exists..
 
         Note:
-            If not self.root variable is set for this object then it is 
+            If not self.root variable is set for this object then it is
             impossible to know if the path exists or not, so it will always
             return False.
 

--- a/tests/test_datcollection.py
+++ b/tests/test_datcollection.py
@@ -6,6 +6,7 @@ from ship.fmp import fmpunitfactory as iuf
 from ship.fmp.datunits import riverunit
 from ship.fmp.datunits import ROW_DATA_TYPES as rdt
 from ship.utils.filetools import PathHolder
+from .utils import fakeAbsPath
 
 
 class IsisUnitCollectionTest(unittest.TestCase):
@@ -15,7 +16,7 @@ class IsisUnitCollectionTest(unittest.TestCase):
     def setUp(self):
         '''Set up stuff that will be used throughout the class.
         '''
-        self.fake_path = 'c:\\fake\\path\\to\\datfile.dat'
+        self.fake_path = fakeAbsPath('c:/fake/path/to/datfile.dat')
         self.path_holder = PathHolder(self.fake_path)
 
         # Setup some data to create units with
@@ -89,7 +90,7 @@ class IsisUnitCollectionTest(unittest.TestCase):
         self.assertEqual(p.filename, 'datfile')
         self.assertEqual(p.extension, 'dat')
         self.assertEqual(p.relative_root, None)
-        self.assertEqual(p.root, 'c:\\fake\\path\\to')
+        self.assertEqual(p.root, fakeAbsPath('c:/fake/path/to'))
 
     def test_initialisedDat(self):
         """Make sure we're creating default setup collections properly."""

--- a/tests/test_filetools.py
+++ b/tests/test_filetools.py
@@ -5,19 +5,19 @@ import unittest
 
 from ship.utils.filetools import PathHolder
 from ship.utils import filetools
-
+from .utils import fakeAbsPath
 
 class PathHolderTests(unittest.TestCase):
-    '''Tests the function and setup of the PathHolder object. 
+    '''Tests the function and setup of the PathHolder object.
 
     '''
 
     def setUp(self):
-        self.fake_root = 'c:\\some\\fake\\root'
-        self.fake_abs_path = 'c:\\first\\second\\third\\fourth\\TuflowFile.txt'
-        self.fake_relative_path = '..\\relative\\TuflowFile.txt'
-        self.no_relative_path = '..\\relative'
-        self.path_with_comment = 'relative\\file.txt ! Some comment'
+        self.fake_root = fakeAbsPath('c:/some/fake/root')
+        self.fake_abs_path = fakeAbsPath('c:/first/second/third/fourth/TuflowFile.txt')
+        self.fake_relative_path = '../relative/TuflowFile.txt'
+        self.no_relative_path = '../relative'
+        self.path_with_comment = 'relative/file.txt ! Some comment'
 
     def test_setupVars(self):
         '''Test the _setupVars method.
@@ -27,14 +27,14 @@ class PathHolderTests(unittest.TestCase):
         '''
         # Check that it loads an absolute path properly
         ph = PathHolder(self.fake_abs_path)
-        self.assertEqual('c:\\first\\second\\third\\fourth', ph.root, 'roots do not match')
+        self.assertEqual(fakeAbsPath('c:/first/second/third/fourth'), ph.root, 'roots do not match')
         self.assertEqual('TuflowFile', ph.filename, 'filenames do not match')
         self.assertEqual('txt', ph.extension, 'extensions do not match')
         self.assertIsNone(ph.relative_root, 'relative root should be None')
 
         # Check that it loads a relative path properly
         ph = PathHolder(self.fake_relative_path)
-        self.assertEqual('..\\relative', ph.relative_root, 'relative roots do not match')
+        self.assertEqual('../relative', ph.relative_root, 'relative roots do not match')
         self.assertEqual('TuflowFile', ph.filename, 'filenames do not match')
         self.assertEqual('txt', ph.extension, 'extensions do not match')
         self.assertIsNone(ph.root, 'root should be None')
@@ -53,11 +53,11 @@ class PathHolderTests(unittest.TestCase):
         '''
         ph = PathHolder(self.fake_abs_path)
         ph.setFinalFolder('fifth')
-        self.assertEqual('c:\\first\\second\\third\\fifth', ph.root, 'set absolute final folder fail')
+        self.assertEqual(fakeAbsPath('c:/first/second/third/fifth'), ph.root, 'set absolute final folder fail')
 
         ph = PathHolder(self.fake_relative_path)
         ph.setFinalFolder('fifth')
-        self.assertEqual('..\\fifth', ph.relative_root, 'set relative final folder fail')
+        self.assertEqual('../fifth', ph.relative_root, 'set relative final folder fail')
 
     def test_absolutePath(self):
         '''Test that the absolute path is returned correctly.
@@ -71,7 +71,7 @@ class PathHolderTests(unittest.TestCase):
 
         ph = PathHolder(self.fake_relative_path, self.fake_root)
         q = ph.absolutePath()
-        self.assertEqual('c:\\some\\fake\\root\\TuflowFile.txt', ph.absolutePath(), 'absolutePath() with root and relative root fail')
+        self.assertEqual(fakeAbsPath('c:/some/fake/root/TuflowFile.txt'), ph.absolutePath(), 'absolutePath() with root and relative root fail')
 
     def test_getDirectory(self):
         '''Check that the function returns the directory properly.

--- a/tests/test_tuflowfactory.py
+++ b/tests/test_tuflowfactory.py
@@ -8,13 +8,14 @@ from ship.tuflow.tuflowfilepart import *  # TuflowPart, TuflowVariable, TuflowFi
 from ship.tuflow import FILEPART_TYPES as ft
 from ship.tuflow import tuflowfactory as f
 
+from .utils import fakeAbsPath
 
 class TuflowFilePartTests(unittest.TestCase):
     """Test the setup of TuflowPart's in the tuflowfactory module."""
 
     def setUp(self):
         """Setup and global variables."""
-        self.fake_root = 'c:/path/to/fake/'
+        self.fake_root = fakeAbsPath('c:/path/to/fake/')
         main_file = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                            'comment': None, 'model_type': 'TCF',
                                            'root': self.fake_root})
@@ -30,11 +31,11 @@ class TuflowFilePartTests(unittest.TestCase):
         bcsource_line = "BC Event Source == evtname | evttext"
         variable_line = "Timestep == 2.5 ! A comment"
         data_line = "Read Materials File == materials.csv"
-        output_line = "Output Folder == ..\\results\\"
-        check_line = "Write Check Files == ..\\checks\\"
+        output_line = "Output Folder == ../results/"
+        check_line = "Write Check Files == ../checks/"
         log_line = "Log Folder == log"
-        gis_line = "Read GIS Z Shape == ..\gis\somefile.shp"
-        model_line = "Geometry Control File == ..\\model\\tgcfile.tgc"
+        gis_line = "Read GIS Z Shape == ../gis/somefile.shp"
+        model_line = "Geometry Control File == ../model/tgcfile.tgc"
 
         self.assertIsInstance(f.TuflowFactory.getTuflowPart(scen_line, self.parent)[0], TuflowModelVariable)
         self.assertIsInstance(f.TuflowFactory.getTuflowPart(event_line, self.parent)[0], TuflowModelVariable)
@@ -148,7 +149,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_createResultType(self):
         """Test construction of ResultFile type."""
-        line = "Output Folder == ..\\results\\"
+        line = "Output Folder == ../results/"
         data = f.TuflowFactory.createResultType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -156,11 +157,11 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, '..\\results\\')
+        self.assertEqual(data.relative_root, '../results/')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 
-        line = "Write Check Files == ..\\checks\\"
+        line = "Write Check Files == ../checks/"
         data = f.TuflowFactory.createResultType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -168,7 +169,7 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, '..\\checks\\')
+        self.assertEqual(data.relative_root, '../checks/')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 #         self.assertTrue(data.filename_is_prefix)
@@ -181,46 +182,46 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, 'log\\')
+        self.assertEqual(data.relative_root, 'log/')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 
     def test_createGisType(self):
         """Test construction of GisFile type."""
-        line = "Read GIS Z Shape == ..\gis\somefile.shp"
+        line = "Read GIS Z Shape == ../gis/somefile.shp"
         data = f.TuflowFactory.createGisType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'shp')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, '../gis')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.shp')
         self.assertEqual(data.gis_type, 'shp')
         self.assertTupleEqual(('shp', 'shx', 'dbf'), data.all_types)
 
-        line = "Read GIS Z Shape == ..\gis\somefile.mif"
+        line = "Read GIS Z Shape == ../gis/somefile.mif"
         data = f.TuflowFactory.createGisType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'mif')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, '../gis')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.mif')
         self.assertEqual(data.gis_type, 'mi')
         self.assertTupleEqual(('mif', 'mid'), data.all_types)
 
-        line = "Read GIS Z Shape == ..\gis\somefile"
+        line = "Read GIS Z Shape == ../gis/somefile"
         data = f.TuflowFactory.createGisType(line, self.parent, test='mif')[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'mif')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, '../gis')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.mif')
         self.assertEqual(data.gis_type, 'mi')
@@ -228,7 +229,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_createModelType(self):
         """Test construction of ModelFile type."""
-        line = "Geometry Control File == ..\\model\\tgcfile.tgc"
+        line = "Geometry Control File == ../model/tgcfile.tgc"
         data = f.TuflowFactory.createModelType(line, self.parent, model_type='TGC')[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -236,13 +237,13 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'model')
         self.assertEqual(data.filename, 'tgcfile')
         self.assertEqual(data.extension, 'tgc')
-        self.assertEqual(data.relative_root, '..\model')
+        self.assertEqual(data.relative_root, '../model')
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'tgcfile.tgc')
         self.assertEqual(data.model_type, 'TGC')
 
     def test_createGisTypeWithPipes(self):
-        line = "Read GIS Z Shape == gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
+        line = "Read GIS Z Shape == gis/somefile_R.shp | gis/somefile_L.shp | gis/somefile_P.shp"
         data = f.TuflowFactory.createGisType(line, self.parent)
         self.assertEqual(len(data), 3)
 
@@ -266,9 +267,9 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_partsFromPipedFiles(self):
         """Check partsFromPipedFiles."""
-#         line = "Read GIS Z Shape == gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
+#         line = "Read GIS Z Shape == gis/somefile_R.shp | gis/somefile_L.shp | gis/somefile_P.shp"
         vars = {}
-        vars['path'] = "gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
+        vars['path'] = "gis/somefile_R.shp | gis/somefile_L.shp | gis/somefile_P.shp"
         vars['command'] = 'Read GIS Z Shape'
         vars['comment'] = ''
         vars['root'] = self.fake_root
@@ -295,9 +296,9 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_assignSiblings(self):
         """Check that sibling assignments are correct."""
-        line1 = "Read GIS Z Shape == gis\somefile_R.shp"
-        line2 = "Read GIS Z Shape == gis\\somefile_L.shp"
-        line3 = "Read GIS Z Shape == gis\\somefile_P.shp"
+        line1 = "Read GIS Z Shape == gis/somefile_R.shp"
+        line2 = "Read GIS Z Shape == gis/somefile_L.shp"
+        line3 = "Read GIS Z Shape == gis/somefile_P.shp"
         gis1 = f.TuflowFactory.createGisType(line1, self.parent)[0]
         gis2 = f.TuflowFactory.createGisType(line2, self.parent)[0]
         gis3 = f.TuflowFactory.createGisType(line3, self.parent)[0]
@@ -372,19 +373,19 @@ class TuflowFilePartTests(unittest.TestCase):
         """
 
         result_vars = {
-            'command': 'Output Folder', 'comment': '', 'path': '..\\results',
+            'command': 'Output Folder', 'comment': '', 'path': '../results',
             'root': self.fake_root
         }
         rpart = ResultFile(self.parent, **result_vars)
         rpart = f.resolveResult(rpart)
         result_vars2 = {
-            'command': 'Output Folder', 'comment': '', 'path': '..\\results\\',
+            'command': 'Output Folder', 'comment': '', 'path': '../results/',
             'root': self.fake_root
         }
         rpart2 = ResultFile(self.parent, **result_vars2)
         rpart2 = f.resolveResult(rpart2)
         result_vars3 = {
-            'command': 'Output Folder', 'comment': '', 'path': 'c:\\path\\to\\results\\',
+            'command': 'Output Folder', 'comment': '', 'path': fakeAbsPath('c:/path/to/results/'),
             'root': self.fake_root
         }
         rpart3 = ResultFile(self.parent, **result_vars3)
@@ -397,13 +398,13 @@ class TuflowFilePartTests(unittest.TestCase):
         lpart = ResultFile(self.parent, **log_vars)
         lpart = f.resolveResult(lpart)
         log_vars2 = {
-            'command': 'Log Folder', 'comment': '', 'path': 'log\\',
+            'command': 'Log Folder', 'comment': '', 'path': 'log/',
             'root': self.fake_root
         }
         lpart2 = ResultFile(self.parent, **log_vars2)
         lpart2 = f.resolveResult(lpart2)
         log_vars3 = {
-            'command': 'Log Folder', 'comment': '', 'path': 'c:\\path\\to\\log',
+            'command': 'Log Folder', 'comment': '', 'path': fakeAbsPath('c:/path/to/log'),
             'root': self.fake_root
         }
         lpart3 = ResultFile(self.parent, **log_vars3)
@@ -423,11 +424,11 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(lpart2.filename, '')
         self.assertEqual(lpart3.filename, '')
 
-        self.assertEqual(rpart.relative_root, '..\\results\\')
-        self.assertEqual(rpart2.relative_root, '..\\results\\')
+        self.assertEqual(rpart.relative_root, '../results/')
+        self.assertEqual(rpart2.relative_root, '../results/')
         self.assertEqual(rpart3.relative_root, '')
-        self.assertEqual(lpart.relative_root, 'log\\')
-        self.assertEqual(lpart2.relative_root, 'log\\')
+        self.assertEqual(lpart.relative_root, 'log/')
+        self.assertEqual(lpart2.relative_root, 'log/')
         self.assertEqual(lpart3.relative_root, '')
 
         self.assertFalse(rpart.filename_is_prefix)
@@ -443,25 +444,25 @@ class TuflowFilePartTests(unittest.TestCase):
         Test the resolveResult function with Write Check Files command.
         """
         check_vars = {
-            'command': 'Write Check Files', 'comment': '', 'path': '..\\check',
+            'command': 'Write Check Files', 'comment': '', 'path': '../check',
             'root': self.fake_root
         }
         cpart = ResultFile(self.parent, **check_vars)
         cpart = f.resolveResult(cpart)
         check_vars2 = {
-            'command': 'Write Check Files', 'comment': '', 'path': '..\\check\\',
+            'command': 'Write Check Files', 'comment': '', 'path': '../check/',
             'root': self.fake_root
         }
         cpart2 = ResultFile(self.parent, **check_vars2)
         cpart2 = f.resolveResult(cpart2)
         check_vars3 = {
-            'command': 'Write Check Files', 'comment': '', 'path': 'c:\\path\\to\\check',
+            'command': 'Write Check Files', 'comment': '', 'path': fakeAbsPath('c:/path/to/check'),
             'root': self.fake_root
         }
         cpart3 = ResultFile(self.parent, **check_vars3)
         cpart3 = f.resolveResult(cpart3)
         check_vars4 = {
-            'command': 'Write Check Files', 'comment': '', 'path': 'c:\\path\\to\\check\\',
+            'command': 'Write Check Files', 'comment': '', 'path': fakeAbsPath('c:/path/to/check/'),
             'root': self.fake_root
         }
         cpart4 = ResultFile(self.parent, **check_vars4)
@@ -477,8 +478,8 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(cpart3.filename, 'check')
         self.assertEqual(cpart4.filename, '')
 
-        self.assertEqual(cpart.relative_root, '..\\')
-        self.assertEqual(cpart2.relative_root, '..\\check\\')
+        self.assertEqual(cpart.relative_root, '../')
+        self.assertEqual(cpart2.relative_root, '../check/')
         self.assertEqual(cpart3.relative_root, '')
         self.assertEqual(cpart4.relative_root, '')
 

--- a/tests/test_tuflowfilepart.py
+++ b/tests/test_tuflowfilepart.py
@@ -8,6 +8,7 @@ from ship.tuflow.tuflowfilepart import TuflowPart
 from ship.tuflow import FILEPART_TYPES as ft
 from ship.tuflow import tuflowfactory as f
 
+from .utils import fakeAbsPath
 
 class TuflowFilePartTests(unittest.TestCase):
     '''Tests TuflowPart's and subclasses.
@@ -19,7 +20,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
         Tests within test_tuflowfactor.py provide decent coverage of creating
         new instances of specific TuflowPart's and checking that they have
-        been instanciated properly. If you need to add tests to check that 
+        been instanciated properly. If you need to add tests to check that
         they have been created properly they should probably go in the factory
         tests.
     '''
@@ -27,30 +28,30 @@ class TuflowFilePartTests(unittest.TestCase):
     def setUp(self):
 
         # Setup a main .tcf file
-        self.fake_root = 'c:/path/to/fake/'
+        self.fake_root = fakeAbsPath('c:/path/to/fake/')
         self.tcf = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                           'comment': None, 'model_type': 'TCF',
                                           'root': self.fake_root})
 
         # Setup a tgc file with tcf parent
-        tgc_line = "Geometry Control File == ..\\model\\tgcfile.tgc ! A tgc comment"
+        tgc_line = "Geometry Control File == ../model/tgcfile.tgc ! A tgc comment"
         self.tgc = f.TuflowFactory.getTuflowPart(tgc_line, self.tcf)[0]
 
         # Setup a gis file with tgc parent
-        gis_line = "Read Gis Z Shape == gis\\gisfile.shp ! A gis comment"
+        gis_line = "Read Gis Z Shape == gis/gisfile.shp ! A gis comment"
         self.gis = f.TuflowFactory.getTuflowPart(gis_line, self.tgc)[0]
         var_line = "Timestep == 2 ! A var comment"
         self.var = f.TuflowFactory.getTuflowPart(var_line, self.tgc)[0]
-        gis_line2 = "Read Gis Z Shape == gis\\gisfile2.shp ! A gis 2 comment"
+        gis_line2 = "Read Gis Z Shape == gis/gisfile2.shp ! A gis 2 comment"
         self.gis2 = f.TuflowFactory.getTuflowPart(gis_line2, self.tgc)[0]
 
         # For the evt testing stuff
-        line_evt = "Read Gis Z Shape == gis\\gisfile_evt.shp ! A gis 3 comment"
+        line_evt = "Read Gis Z Shape == gis/gisfile_evt.shp ! A gis 3 comment"
         self.gis_evt = f.TuflowFactory.getTuflowPart(line_evt, self.tgc)[0]
         linevar_evt = "Timestep == 6 ! A var evt comment"
         self.var_evt = f.TuflowFactory.getTuflowPart(linevar_evt, self.tgc)[0]
         # For the scenario testing stuff
-        line_scen = "Read Gis Z Shape == gis\\gisfile_evt.shp ! A gis 3 comment"
+        line_scen = "Read Gis Z Shape == gis/gisfile_evt.shp ! A gis 3 comment"
         self.gis_scen = f.TuflowFactory.getTuflowPart(line_scen, self.tgc)[0]
         linevar_scen = "Timestep == 6 ! A var scen comment"
         self.var_scen = f.TuflowFactory.getTuflowPart(linevar_scen, self.tgc)[0]
@@ -130,7 +131,7 @@ class TuflowFilePartTests(unittest.TestCase):
             's1': 'scen1', 'size': '10', 'e1': 'event1', 'anothervar': '2.5'
         }
         path = vardata.absolutePath(user_vars=user_vars)
-        self.assertEqual('c:\\path\\to\\model\\Materials_scen1.tmf', path)
+        self.assertEqual(fakeAbsPath('c:/path/to/model/Materials_scen1.tmf'), path)
         var = TuflowPart.resolvePlaceholder(varvar.variable, user_vars)
         var2 = varvar.resolvedVariable(user_vars)
         var3 = varvar.resolvePlaceholder(varvar.variable, user_vars=user_vars)
@@ -140,8 +141,8 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_TFabsolutePath(self):
         """Test return value of absolutePath in TuflowFile."""
-        path1 = 'c:\\path\\to\\model\\tgcfile.tgc'
-        path2 = 'c:\\path\\to\\model\\gis\\gisfile.shp'
+        path1 = fakeAbsPath('c:/path/to/model/tgcfile.tgc')
+        path2 = fakeAbsPath('c:/path/to/model/gis/gisfile.shp')
         self.assertEqual(path1, self.tgc.absolutePath())
         self.assertEqual(path2, self.gis.absolutePath())
 
@@ -151,15 +152,15 @@ class TuflowFilePartTests(unittest.TestCase):
         This will return the same as absolutePath if there is only one associated
         file extension. Otherwise it will return one path for each type.
         """
-        paths = ['c:\\path\\to\\model\\gis\\gisfile.shp',
-                 'c:\\path\\to\\model\\gis\\gisfile.shx',
-                 'c:\\path\\to\\model\\gis\\gisfile.dbf']
+        paths = [fakeAbsPath('c:/path/to/model/gis/gisfile.shp'),
+                 fakeAbsPath('c:/path/to/model/gis/gisfile.shx'),
+                 fakeAbsPath('c:/path/to/model/gis/gisfile.dbf')]
         self.assertListEqual(paths, self.gis.absolutePathAllTypes())
 
     def test_TFrelativePath(self):
         """Test return value of relativePaths in TuflowFile."""
-        path1 = ['..\\model']
-        path2 = ['..\\model', 'gis']
+        path1 = ['../model']
+        path2 = ['../model', 'gis']
         self.assertListEqual(path1, self.tgc.getRelativeRoots([]))
         self.assertListEqual(path2, self.gis.getRelativeRoots([]))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,21 @@
+import os
+
+def fakeAbsPath(path):
+    '''
+    Make a pretend filepath 'absolute' for the current os.
+    Will massage absolute paths for the wrong OS to abs paths
+    for current os
+    '''
+    if os.path.isabs(path):
+        # It is already an absolut path
+        newpath = path
+    elif os.name == 'posix':
+        # We may have been given a windows path, so remove the drive and
+        # make it root dir
+        newpath = path.replace('c:', '').replace('\\', os.sep)
+        if not newpath.startswith('/'):
+            newpath = '/{}'.format(newpath)
+    else:
+        newpath = 'c:{}{}'.format(os.sep, path)
+
+    return newpath


### PR DESCRIPTION
This PR updates the tests to pass on linux. 
I have not been able to check these tests are still ok on windows yet, so this would need double checking first. 

It consists of 3 main changes:
- Replace all backslashes with forward slashes. Windows fully supports forward slashes as directory separators, so shouldn't be a problem (although Im not sure if tuflow requires backslashes on windows or not). 

- Added a utility function to make all the fake absolute paths platform specific. (Basically just checks the platform and if it is linux, replaces the drive letter with a forward slash)

- The above resulted in 1 failing test so I had to change some code in filetools (`setFinalFolder`) which stripped the preceding '/' on linux paths. It *should* do exactly the same thing as previous code (?)

Hopefully this is a first small step toward ensuring x platform support. 
