### PR TITLE
Simplify filetools

### DIFF
--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -3,30 +3,30 @@
  Summary:
     Contains file access functions and classes.
 
-    This module contains convenience functions and classes for reading and 
+    This module contains convenience functions and classes for reading and
     writing files and launching different types of File dialogue.
-    
+
     Some of the functionality needed in this class is provided by the PyQt
     framework. When this module is loaded it tries to import the PyQt module.
     If it fails it sets a HAS_QT flag to False.
-    
+
     Before any attempts to use the PyQt functions are made the HAS_QT flag
     is checked. If it's false the function will react.
 
- Author:  
+ Author:
      Duncan Runnacles
-     
-  Created:  
+
+  Created:
      01 Apr 2016
- 
- Copyright:  
+
+ Copyright:
      Duncan Runnacles 2016
 
  TODO: This module, like a lot of other probably, needs reviewing for how
          'Pythonic' t is. There are a lot of places where generators,
          comprehensions, maps, etc should be used to speed things up and make
          them a bit clearer.
-         
+
          More importantly there are a lot of places using '==' compare that
          should be using 'in' etc. This could cause bugs and must be fixed
          soon.
@@ -47,7 +47,7 @@ from ship.utils import utilfunctions as uf
 
 
 HAS_QT = True
-"""If Qt is not installed on the machine running the library we can't use any 
+"""If Qt is not installed on the machine running the library we can't use any
 of the GUI related code, such as file dialogs. This flag informs the code in
 the module about the load status.
 """
@@ -132,7 +132,7 @@ def directoryFileNames(path):
         List - filenames in directory.
 
     Raises:
-        IOError: If there's a problem with the read/write or the directory 
+        IOError: If there's a problem with the read/write or the directory
             doesn't exist
         TypeError: if string not given for file_path.
     """
@@ -193,7 +193,7 @@ def getOpenFileDialog(path='', types='All (*.*)', multi_file=True):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
         multi_file=True(bool): If False user can only select a single file.
 
     Returns:
@@ -228,7 +228,7 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
 
     Returns:
         Str containing path is successful or False if not.
@@ -252,9 +252,9 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
 
 """
-###############################                                                                         
-  Path Functions and classes                                                 
-###############################                                                                         
+###############################
+  Path Functions and classes
+###############################
 """
 
 
@@ -262,7 +262,7 @@ def pathExists(path):
     """Test whether a path exists.
 
     Args:
-        path (str):  the path to test. 
+        path (str):  the path to test.
 
     Returns:
         True if the path exists or False if it doesn't.
@@ -326,11 +326,11 @@ def getFileName(in_path, with_extension=False):
 
     Args:
         in_path (str): the file path to extract the filename from.
-        with_extension=False (Bool): flag denoting whether to return 
+        with_extension=False (Bool): flag denoting whether to return
             the filename with or without the extension.
 
     Returns:
-        Str - file name, with or without the extension appended or a 
+        Str - file name, with or without the extension appended or a
              blank string if there is no file name in the path.
     """
     filename = os.path.basename(in_path)
@@ -348,15 +348,15 @@ def getFileName(in_path, with_extension=False):
 def directory(in_path):
     """Get the directory component of the given path.
 
-    Checks the given path to see if it has a file or not. 
+    Checks the given path to see if it has a file or not.
 
-    If there is no file component in the path it will return the path as-is. 
+    If there is no file component in the path it will return the path as-is.
 
-    If there is no directory component in the file it will return a 
+    If there is no directory component in the file it will return a
     blank string.
 
     Args:
-        in_path (str): the path to extract the directory from.   
+        in_path (str): the path to extract the directory from.
 
     Returns:
         Str - directory component of the given file path.
@@ -396,11 +396,11 @@ class PathHolder(object):
         """Constructor.
 
         Args:
-            path (str): the path to the file that this object holds the meta 
+            path (str): the path to the file that this object holds the meta
                 data for.
-            root (str): Optional - the path to the directory that is the root 
-                of this file. Most tuflow files are referenced relative to the 
-                file that they are called from. The root will allow for an 
+            root (str): Optional - the path to the directory that is the root
+                of this file. Most tuflow files are referenced relative to the
+                file that they are called from. The root will allow for an
                 absolute path to be created from the relative path.
         """
 #         if not isinstance(path, basestring):
@@ -442,13 +442,13 @@ class PathHolder(object):
     def finalFolder(self):
         """Get the last folder in the path.
 
-        If the relative_root variable is set it will be taken from that. 
-        Otherwise if it is not and the root variable is set it will be taken 
+        If the relative_root variable is set it will be taken from that.
+        Otherwise if it is not and the root variable is set it will be taken
         from that. If nether are set it will return False.
 
         Returns:
-            tuple - the first part of the directory path and the final 
-                folder in the directory path for this file, or False if the 
+            tuple - the first part of the directory path and the final
+                folder in the directory path for this file, or False if the
                 variable has not been set.
         """
         final_folder = False
@@ -480,8 +480,8 @@ class PathHolder(object):
         is no way of knowing what the absolute path will be.
 
         Args:
-            filename: Optional - if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename: Optional - if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -492,42 +492,18 @@ class PathHolder(object):
 
         outpath = False
         if relative_roots and not self.root is None:
-            #         if not self.root == None and not self.relative_root == None:
             paths = [self.root] + relative_roots + [filename]
             if normalize:
                 outpath = os.path.normpath(os.path.join(*paths))
             else:
                 outpath = os.path.join(*paths)
-#             return os.path.join(self.root, self.parent_relative_root,
-#                                         self.relative_root, filename)
-
-
-#             if not filename == None:
-#                 return os.path.join(self.root, self.parent_relative_root,
-#                                         self.relative_root, filename)
-#
-#             else:
-#                 return os.path.join(self.root, self.parent_relative_root,
-#                             self.relative_root, self.filenameAndExtension())
-
-#         elif not self.root == None and self.relative_root == None:
         elif not self.root is None:
             if normalize:
                 outpath = os.path.normpath(os.path.join(self.root, filename))
             else:
                 outpath = os.path.join(self.root, filename)
-#             if not filename == None:
-#                 return os.path.join(self.root, filename)
-#
-#             else:
-#                 return os.path.join(self.root, self.filenameAndExtension())
-
         return outpath
-#         else:
-#             return outpath
 
-
-#     def getDirectory(self):
     def directory(self):
         """Get the directory of the file path stored in this object.
 
@@ -551,19 +527,18 @@ class PathHolder(object):
             return False
 
 
-#     def getRelativePath(self, with_extension=True, filename=None):
     def relativePath(self, with_extension=True, filename=None):
         """Returns the full relative root with filename for this object.
 
 
-        If a relative root was given to the constructor or set later this will 
+        If a relative root was given to the constructor or set later this will
         return it, otherwise it will return False.
 
         Args:
             with_extension=True (bool): append the extension to the end of the
                 path if True.
-            filename=None (str): if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename=None (str): if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -583,7 +558,6 @@ class PathHolder(object):
         return False
 
 
-#     def getFileNameAndExtension(self):
     def filenameAndExtension(self):
         """Return the file name with the file extension appended.
 
@@ -599,31 +573,30 @@ class PathHolder(object):
             return ''
 
 
-#     def setPathsWithAbsolutePath(self, absolute_path, keep_relative_root=False):
     def setAbsolutePath(self, absolute_path, keep_relative_root=False):
         """Sets the absolute path of this object.
 
         Takes an absolute path and set the file variables in this object with
-        it. 
+        it.
 
         Note:
-            This function WILL NOT check that the path exists. If the path used 
-            to call this function must exist it is the responsibility of the 
+            This function WILL NOT check that the path exists. If the path used
+            to call this function must exist it is the responsibility of the
             caller to check this.
 
         keep_relative_root variable information:
 
-        If a relative root is not set to None it will be included in any path 
-        that is returned by this object. i.e. when an absolute path is 
-        returned by this object it will return: 
+        If a relative root is not set to None it will be included in any path
+        that is returned by this object. i.e. when an absolute path is
+        returned by this object it will return:
 
         path + relativepath + filename + extension
 
         Args:
             absolute_path (str): the new absolute path to use to set the file
                 variables in this object.
-            keep_relative_root=False (Bool): if a relative root exists for 
-                this object it will be set to None unless this variable is 
+            keep_relative_root=False (Bool): if a relative root exists for
+                this object it will be set to None unless this variable is
                 set to True.         """
         absolute_path = absolute_path.strip()
         self.root, filename = os.path.split(absolute_path)
@@ -634,7 +607,6 @@ class PathHolder(object):
             self.relative_root = None
 
 
-#     def setFileName(self, filename, has_extension=False, keep_extension=False):
     def setFilename(self, filename, has_extension=False, keep_extension=False):
         """Updates the filename variables with the given file name.
 
@@ -645,10 +617,10 @@ class PathHolder(object):
 
         Args:
             filename (str): the new filename to set.
-            has_extension=False (Bool): whether the filename has a file 
-                extension or not. This should be set to True if an extension 
-                exists. Otherwise the filename will be corrupted. 
-            keep_extension: if the caller want to keep the extension on the 
+            has_extension=False (Bool): whether the filename has a file
+                extension or not. This should be set to True if an extension
+                exists. Otherwise the filename will be corrupted.
+            keep_extension: if the caller want to keep the extension on the
                given filename this should be True. Otherwise the file extension
                on the new filename will be discarded.
         """
@@ -663,12 +635,11 @@ class PathHolder(object):
                 self.filename = filename
 
 
-#     def getPathExists(self, ext=None):
     def pathExists(self, ext=None):
         """Test whether the path exists..
 
         Note:
-            If not self.root variable is set for this object then it is 
+            If not self.root variable is set for this object then it is
             impossible to know if the path exists or not, so it will always
             return False.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -38,23 +38,21 @@
 from __future__ import unicode_literals
 
 import os
-
 import logging
-logger = logging.getLogger(__name__)
-"""logging references with a __name__ set to this module."""
 
 from ship.utils import utilfunctions as uf
 
+# logging references with a __name__ set to this module.
+logger = logging.getLogger(__name__)
 
+# If Qt is not installed on the machine running the library we can't use any
+# of the GUI related code, such as file dialogs. This flag informs the code in
+# the module about the load status.
 HAS_QT = True
-"""If Qt is not installed on the machine running the library we can't use any
-of the GUI related code, such as file dialogs. This flag informs the code in
-the module about the load status.
-"""
+
 
 try:
     from ship.utils.qtclasses import MyFileDialogs
-
 except Exception:
     logger.warning('Unable to load Qt modules - cannot launch file dialogues')
     HAS_QT = False
@@ -251,12 +249,10 @@ def getSaveFileDialog(path='', types='All (*.*)'):
         return False
 
 
-"""
-###############################
-  Path Functions and classes
-###############################
-"""
 
+###############################
+#  Path Functions and classes #
+###############################
 
 def pathExists(path):
     """Test whether a path exists.
@@ -403,16 +399,12 @@ class PathHolder(object):
                 file that they are called from. The root will allow for an
                 absolute path to be created from the relative path.
         """
-#         if not isinstance(path, basestring):
-#         if not type(path) in (str, unicode):
-#             raise TypeError
 
         self.root = root
         self.relative_root = None
         self.filename = None
         self.extension = None
         self.path_as_read = None
-#         self.parent_relative_root = ''
 
         self._setupVars(path)
 
@@ -472,7 +464,6 @@ class PathHolder(object):
             self.root = setFinalFolder(self.root, folder_name)
 
 
-#     def getAbsolutePath(self, filename=None, relative_roots=[], normalize=True):
     def absolutePath(self, filename=None, relative_roots=[], normalize=True):
         """Get the absolute path of the file path stored in this object.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -254,21 +254,6 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 #  Path Functions and classes #
 ###############################
 
-def pathExists(path):
-    """Test whether a path exists.
-
-    Args:
-        path (str):  the path to test.
-
-    Returns:
-        True if the path exists or False if it doesn't.
-    """
-    if os.path.exists(path):
-        return True
-
-    return False
-
-
 def finalFolder(path):
     """Get the last folder in the path.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -278,29 +278,7 @@ def setFinalFolder(path, folder_name):
     """
     # Normalise the path so that we don't get any funny behaviour
     norm_path = os.path.normpath(path)
-
-    # Get the drive letter
-    drive_letter = os.path.splitdrive(norm_path)[0]
-
-    # Separate out the different folders.
-    # If it's an absolute path then we need to deal with the usual drive
-    # letter problems (doesn't join it back with a slash.
-    plist = norm_path.split(os.sep)
-    if drive_letter:
-        all_but_final_folder = plist[1:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-        all_but_final_folder = plist[0] + os.path.sep + all_but_final_folder
-        all_but_final_folder = os.path.normpath(all_but_final_folder)
-
-    # Otherwise just remove the final folder so that we can replace it
-    # with the new one.
-    else:
-        all_but_final_folder = plist[:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-
-    # Add the new folder name to the end
-    return os.path.join(all_but_final_folder, folder_name)
-
+    return os.path.join(os.path.dirname(path), folder_name)
 
 def getFileName(in_path, with_extension=False):
     """Return the file name with the file extension appended.
@@ -415,7 +393,6 @@ class PathHolder(object):
             self.setFilename(getFileName(path, True), True, True)
 
 
-#     def getFinalFolder(self):
     def finalFolder(self):
         """Get the last folder in the path.
 


### PR DESCRIPTION
This simplifies the `finalFolder` function (also enabling it to work on linux) and removes some previously commented code sections. 

There are a few other simplifications I think could be useful, but would subtly change behaviour. I'll bring these up in #6