### PR TITLE
Path holder

### DIFF
--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -3,30 +3,30 @@
  Summary:
     Contains file access functions and classes.
 
-    This module contains convenience functions and classes for reading and 
+    This module contains convenience functions and classes for reading and
     writing files and launching different types of File dialogue.
-    
+
     Some of the functionality needed in this class is provided by the PyQt
     framework. When this module is loaded it tries to import the PyQt module.
     If it fails it sets a HAS_QT flag to False.
-    
+
     Before any attempts to use the PyQt functions are made the HAS_QT flag
     is checked. If it's false the function will react.
 
- Author:  
+ Author:
      Duncan Runnacles
-     
-  Created:  
+
+  Created:
      01 Apr 2016
- 
- Copyright:  
+
+ Copyright:
      Duncan Runnacles 2016
 
  TODO: This module, like a lot of other probably, needs reviewing for how
          'Pythonic' t is. There are a lot of places where generators,
          comprehensions, maps, etc should be used to speed things up and make
          them a bit clearer.
-         
+
          More importantly there are a lot of places using '==' compare that
          should be using 'in' etc. This could cause bugs and must be fixed
          soon.
@@ -47,7 +47,7 @@ from ship.utils import utilfunctions as uf
 
 
 HAS_QT = True
-"""If Qt is not installed on the machine running the library we can't use any 
+"""If Qt is not installed on the machine running the library we can't use any
 of the GUI related code, such as file dialogs. This flag informs the code in
 the module about the load status.
 """
@@ -132,7 +132,7 @@ def directoryFileNames(path):
         List - filenames in directory.
 
     Raises:
-        IOError: If there's a problem with the read/write or the directory 
+        IOError: If there's a problem with the read/write or the directory
             doesn't exist
         TypeError: if string not given for file_path.
     """
@@ -193,7 +193,7 @@ def getOpenFileDialog(path='', types='All (*.*)', multi_file=True):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
         multi_file=True(bool): If False user can only select a single file.
 
     Returns:
@@ -228,7 +228,7 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
     Args:
         path (str): Optional -  directory to open the dialog in.
-        types (str): Optional - file types to restrict to. 
+        types (str): Optional - file types to restrict to.
 
     Returns:
         Str containing path is successful or False if not.
@@ -252,9 +252,9 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 
 
 """
-###############################                                                                         
-  Path Functions and classes                                                 
-###############################                                                                         
+###############################
+  Path Functions and classes
+###############################
 """
 
 
@@ -262,7 +262,7 @@ def pathExists(path):
     """Test whether a path exists.
 
     Args:
-        path (str):  the path to test. 
+        path (str):  the path to test.
 
     Returns:
         True if the path exists or False if it doesn't.
@@ -326,11 +326,11 @@ def getFileName(in_path, with_extension=False):
 
     Args:
         in_path (str): the file path to extract the filename from.
-        with_extension=False (Bool): flag denoting whether to return 
+        with_extension=False (Bool): flag denoting whether to return
             the filename with or without the extension.
 
     Returns:
-        Str - file name, with or without the extension appended or a 
+        Str - file name, with or without the extension appended or a
              blank string if there is no file name in the path.
     """
     filename = os.path.basename(in_path)
@@ -348,15 +348,15 @@ def getFileName(in_path, with_extension=False):
 def directory(in_path):
     """Get the directory component of the given path.
 
-    Checks the given path to see if it has a file or not. 
+    Checks the given path to see if it has a file or not.
 
-    If there is no file component in the path it will return the path as-is. 
+    If there is no file component in the path it will return the path as-is.
 
-    If there is no directory component in the file it will return a 
+    If there is no directory component in the file it will return a
     blank string.
 
     Args:
-        in_path (str): the path to extract the directory from.   
+        in_path (str): the path to extract the directory from.
 
     Returns:
         Str - directory component of the given file path.
@@ -396,11 +396,11 @@ class PathHolder(object):
         """Constructor.
 
         Args:
-            path (str): the path to the file that this object holds the meta 
+            path (str): the path to the file that this object holds the meta
                 data for.
-            root (str): Optional - the path to the directory that is the root 
-                of this file. Most tuflow files are referenced relative to the 
-                file that they are called from. The root will allow for an 
+            root (str): Optional - the path to the directory that is the root
+                of this file. Most tuflow files are referenced relative to the
+                file that they are called from. The root will allow for an
                 absolute path to be created from the relative path.
         """
 #         if not isinstance(path, basestring):
@@ -442,13 +442,13 @@ class PathHolder(object):
     def finalFolder(self):
         """Get the last folder in the path.
 
-        If the relative_root variable is set it will be taken from that. 
-        Otherwise if it is not and the root variable is set it will be taken 
+        If the relative_root variable is set it will be taken from that.
+        Otherwise if it is not and the root variable is set it will be taken
         from that. If nether are set it will return False.
 
         Returns:
-            tuple - the first part of the directory path and the final 
-                folder in the directory path for this file, or False if the 
+            tuple - the first part of the directory path and the final
+                folder in the directory path for this file, or False if the
                 variable has not been set.
         """
         final_folder = False
@@ -480,8 +480,8 @@ class PathHolder(object):
         is no way of knowing what the absolute path will be.
 
         Args:
-            filename: Optional - if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename: Optional - if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -492,42 +492,18 @@ class PathHolder(object):
 
         outpath = False
         if relative_roots and not self.root is None:
-            #         if not self.root == None and not self.relative_root == None:
             paths = [self.root] + relative_roots + [filename]
             if normalize:
                 outpath = os.path.normpath(os.path.join(*paths))
             else:
                 outpath = os.path.join(*paths)
-#             return os.path.join(self.root, self.parent_relative_root,
-#                                         self.relative_root, filename)
-
-
-#             if not filename == None:
-#                 return os.path.join(self.root, self.parent_relative_root,
-#                                         self.relative_root, filename)
-#
-#             else:
-#                 return os.path.join(self.root, self.parent_relative_root,
-#                             self.relative_root, self.filenameAndExtension())
-
-#         elif not self.root == None and self.relative_root == None:
         elif not self.root is None:
             if normalize:
                 outpath = os.path.normpath(os.path.join(self.root, filename))
             else:
                 outpath = os.path.join(self.root, filename)
-#             if not filename == None:
-#                 return os.path.join(self.root, filename)
-#
-#             else:
-#                 return os.path.join(self.root, self.filenameAndExtension())
-
         return outpath
-#         else:
-#             return outpath
 
-
-#     def getDirectory(self):
     def directory(self):
         """Get the directory of the file path stored in this object.
 
@@ -551,19 +527,18 @@ class PathHolder(object):
             return False
 
 
-#     def getRelativePath(self, with_extension=True, filename=None):
     def relativePath(self, with_extension=True, filename=None):
         """Returns the full relative root with filename for this object.
 
 
-        If a relative root was given to the constructor or set later this will 
+        If a relative root was given to the constructor or set later this will
         return it, otherwise it will return False.
 
         Args:
             with_extension=True (bool): append the extension to the end of the
                 path if True.
-            filename=None (str): if a different file name to the one 
-                currently stored in this object is required it can be 
+            filename=None (str): if a different file name to the one
+                currently stored in this object is required it can be
                 specified with this variable.
 
         Returns:
@@ -583,7 +558,6 @@ class PathHolder(object):
         return False
 
 
-#     def getFileNameAndExtension(self):
     def filenameAndExtension(self):
         """Return the file name with the file extension appended.
 
@@ -599,31 +573,30 @@ class PathHolder(object):
             return ''
 
 
-#     def setPathsWithAbsolutePath(self, absolute_path, keep_relative_root=False):
     def setAbsolutePath(self, absolute_path, keep_relative_root=False):
         """Sets the absolute path of this object.
 
         Takes an absolute path and set the file variables in this object with
-        it. 
+        it.
 
         Note:
-            This function WILL NOT check that the path exists. If the path used 
-            to call this function must exist it is the responsibility of the 
+            This function WILL NOT check that the path exists. If the path used
+            to call this function must exist it is the responsibility of the
             caller to check this.
 
         keep_relative_root variable information:
 
-        If a relative root is not set to None it will be included in any path 
-        that is returned by this object. i.e. when an absolute path is 
-        returned by this object it will return: 
+        If a relative root is not set to None it will be included in any path
+        that is returned by this object. i.e. when an absolute path is
+        returned by this object it will return:
 
         path + relativepath + filename + extension
 
         Args:
             absolute_path (str): the new absolute path to use to set the file
                 variables in this object.
-            keep_relative_root=False (Bool): if a relative root exists for 
-                this object it will be set to None unless this variable is 
+            keep_relative_root=False (Bool): if a relative root exists for
+                this object it will be set to None unless this variable is
                 set to True.         """
         absolute_path = absolute_path.strip()
         self.root, filename = os.path.split(absolute_path)
@@ -634,7 +607,6 @@ class PathHolder(object):
             self.relative_root = None
 
 
-#     def setFileName(self, filename, has_extension=False, keep_extension=False):
     def setFilename(self, filename, has_extension=False, keep_extension=False):
         """Updates the filename variables with the given file name.
 
@@ -645,10 +617,10 @@ class PathHolder(object):
 
         Args:
             filename (str): the new filename to set.
-            has_extension=False (Bool): whether the filename has a file 
-                extension or not. This should be set to True if an extension 
-                exists. Otherwise the filename will be corrupted. 
-            keep_extension: if the caller want to keep the extension on the 
+            has_extension=False (Bool): whether the filename has a file
+                extension or not. This should be set to True if an extension
+                exists. Otherwise the filename will be corrupted.
+            keep_extension: if the caller want to keep the extension on the
                given filename this should be True. Otherwise the file extension
                on the new filename will be discarded.
         """
@@ -663,12 +635,11 @@ class PathHolder(object):
                 self.filename = filename
 
 
-#     def getPathExists(self, ext=None):
     def pathExists(self, ext=None):
         """Test whether the path exists..
 
         Note:
-            If not self.root variable is set for this object then it is 
+            If not self.root variable is set for this object then it is
             impossible to know if the path exists or not, so it will always
             return False.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -38,23 +38,21 @@
 from __future__ import unicode_literals
 
 import os
-
 import logging
-logger = logging.getLogger(__name__)
-"""logging references with a __name__ set to this module."""
 
 from ship.utils import utilfunctions as uf
 
+# logging references with a __name__ set to this module.
+logger = logging.getLogger(__name__)
 
+# If Qt is not installed on the machine running the library we can't use any
+# of the GUI related code, such as file dialogs. This flag informs the code in
+# the module about the load status.
 HAS_QT = True
-"""If Qt is not installed on the machine running the library we can't use any
-of the GUI related code, such as file dialogs. This flag informs the code in
-the module about the load status.
-"""
+
 
 try:
     from ship.utils.qtclasses import MyFileDialogs
-
 except Exception:
     logger.warning('Unable to load Qt modules - cannot launch file dialogues')
     HAS_QT = False
@@ -251,12 +249,10 @@ def getSaveFileDialog(path='', types='All (*.*)'):
         return False
 
 
-"""
-###############################
-  Path Functions and classes
-###############################
-"""
 
+###############################
+#  Path Functions and classes #
+###############################
 
 def pathExists(path):
     """Test whether a path exists.
@@ -403,16 +399,12 @@ class PathHolder(object):
                 file that they are called from. The root will allow for an
                 absolute path to be created from the relative path.
         """
-#         if not isinstance(path, basestring):
-#         if not type(path) in (str, unicode):
-#             raise TypeError
 
         self.root = root
         self.relative_root = None
         self.filename = None
         self.extension = None
         self.path_as_read = None
-#         self.parent_relative_root = ''
 
         self._setupVars(path)
 
@@ -472,7 +464,6 @@ class PathHolder(object):
             self.root = setFinalFolder(self.root, folder_name)
 
 
-#     def getAbsolutePath(self, filename=None, relative_roots=[], normalize=True):
     def absolutePath(self, filename=None, relative_roots=[], normalize=True):
         """Get the absolute path of the file path stored in this object.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -254,21 +254,6 @@ def getSaveFileDialog(path='', types='All (*.*)'):
 #  Path Functions and classes #
 ###############################
 
-def pathExists(path):
-    """Test whether a path exists.
-
-    Args:
-        path (str):  the path to test.
-
-    Returns:
-        True if the path exists or False if it doesn't.
-    """
-    if os.path.exists(path):
-        return True
-
-    return False
-
-
 def finalFolder(path):
     """Get the last folder in the path.
 

--- a/ship/utils/filetools.py
+++ b/ship/utils/filetools.py
@@ -278,29 +278,7 @@ def setFinalFolder(path, folder_name):
     """
     # Normalise the path so that we don't get any funny behaviour
     norm_path = os.path.normpath(path)
-
-    # Get the drive letter
-    drive_letter = os.path.splitdrive(norm_path)[0]
-
-    # Separate out the different folders.
-    # If it's an absolute path then we need to deal with the usual drive
-    # letter problems (doesn't join it back with a slash.
-    plist = norm_path.split(os.sep)
-    if drive_letter:
-        all_but_final_folder = plist[1:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-        all_but_final_folder = plist[0] + os.path.sep + all_but_final_folder
-        all_but_final_folder = os.path.normpath(all_but_final_folder)
-
-    # Otherwise just remove the final folder so that we can replace it
-    # with the new one.
-    else:
-        all_but_final_folder = plist[:-1]
-        all_but_final_folder = os.path.join(*all_but_final_folder)
-
-    # Add the new folder name to the end
-    return os.path.join(all_but_final_folder, folder_name)
-
+    return os.path.join(os.path.dirname(path), folder_name)
 
 def getFileName(in_path, with_extension=False):
     """Return the file name with the file extension appended.
@@ -415,7 +393,6 @@ class PathHolder(object):
             self.setFilename(getFileName(path, True), True, True)
 
 
-#     def getFinalFolder(self):
     def finalFolder(self):
         """Get the last folder in the path.
 

--- a/tests/test_datcollection.py
+++ b/tests/test_datcollection.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import os
 import unittest
 from ship.fmp.datcollection import DatCollection
 from ship.fmp import fmpunitfactory as iuf
@@ -15,7 +16,10 @@ class IsisUnitCollectionTest(unittest.TestCase):
     def setUp(self):
         '''Set up stuff that will be used throughout the class.
         '''
-        self.fake_path = 'c:\\fake\\path\\to\\datfile.dat'
+        self.prefix = '/'
+        if os.name != 'posix':
+            self.prefix = 'c:'
+        self.fake_path = os.path.join(self.prefix, 'fake', 'path', 'to', 'datfile.dat')
         self.path_holder = PathHolder(self.fake_path)
 
         # Setup some data to create units with
@@ -89,7 +93,7 @@ class IsisUnitCollectionTest(unittest.TestCase):
         self.assertEqual(p.filename, 'datfile')
         self.assertEqual(p.extension, 'dat')
         self.assertEqual(p.relative_root, None)
-        self.assertEqual(p.root, 'c:\\fake\\path\\to')
+        self.assertEqual(p.root, os.path.dirname(self.fake_path))
 
     def test_initialisedDat(self):
         """Make sure we're creating default setup collections properly."""

--- a/tests/test_datcollection.py
+++ b/tests/test_datcollection.py
@@ -18,7 +18,7 @@ class IsisUnitCollectionTest(unittest.TestCase):
         '''
         self.prefix = '/'
         if os.name != 'posix':
-            self.prefix = 'c:'
+            self.prefix = 'c:' + os.sep
         self.fake_path = os.path.join(self.prefix, 'fake', 'path', 'to', 'datfile.dat')
         self.path_holder = PathHolder(self.fake_path)
 

--- a/tests/test_filetools.py
+++ b/tests/test_filetools.py
@@ -14,7 +14,7 @@ class PathHolderTests(unittest.TestCase):
     def setUp(self):
         self.prefix = '/'
         if os.name != 'posix':
-            self.prefix = 'c:'
+            self.prefix = 'c:' + os.sep
 
         self.fake_root = os.path.join(self.prefix, 'some', 'fake', 'root')
         self.fake_abs_path = os.path.join(

--- a/tests/test_filetools.py
+++ b/tests/test_filetools.py
@@ -6,18 +6,22 @@ import unittest
 from ship.utils.filetools import PathHolder
 from ship.utils import filetools
 
-
 class PathHolderTests(unittest.TestCase):
-    '''Tests the function and setup of the PathHolder object. 
+    '''Tests the function and setup of the PathHolder object.
 
     '''
 
     def setUp(self):
-        self.fake_root = 'c:\\some\\fake\\root'
-        self.fake_abs_path = 'c:\\first\\second\\third\\fourth\\TuflowFile.txt'
-        self.fake_relative_path = '..\\relative\\TuflowFile.txt'
-        self.no_relative_path = '..\\relative'
-        self.path_with_comment = 'relative\\file.txt ! Some comment'
+        self.prefix = '/'
+        if os.name != 'posix':
+            self.prefix = 'c:'
+
+        self.fake_root = os.path.join(self.prefix, 'some', 'fake', 'root')
+        self.fake_abs_path = os.path.join(
+            self.prefix, 'first', 'second', 'third', 'fourth', 'TuflowFile.txt')
+        self.fake_relative_path = os.path.join('..', 'relative', 'TuflowFile.txt')
+        self.no_relative_path = os.path.join('..', 'relative')
+        self.path_with_comment = os.path.join('relative', 'file.txt') + ' ! Some comment'
 
     def test_setupVars(self):
         '''Test the _setupVars method.
@@ -27,14 +31,15 @@ class PathHolderTests(unittest.TestCase):
         '''
         # Check that it loads an absolute path properly
         ph = PathHolder(self.fake_abs_path)
-        self.assertEqual('c:\\first\\second\\third\\fourth', ph.root, 'roots do not match')
+        pth = os.path.join(self.prefix, 'first', 'second', 'third', 'fourth' )
+        self.assertEqual(pth, ph.root, 'roots do not match')
         self.assertEqual('TuflowFile', ph.filename, 'filenames do not match')
         self.assertEqual('txt', ph.extension, 'extensions do not match')
         self.assertIsNone(ph.relative_root, 'relative root should be None')
 
         # Check that it loads a relative path properly
         ph = PathHolder(self.fake_relative_path)
-        self.assertEqual('..\\relative', ph.relative_root, 'relative roots do not match')
+        self.assertEqual(os.path.join('..', 'relative'), ph.relative_root, 'relative roots do not match')
         self.assertEqual('TuflowFile', ph.filename, 'filenames do not match')
         self.assertEqual('txt', ph.extension, 'extensions do not match')
         self.assertIsNone(ph.root, 'root should be None')
@@ -53,11 +58,12 @@ class PathHolderTests(unittest.TestCase):
         '''
         ph = PathHolder(self.fake_abs_path)
         ph.setFinalFolder('fifth')
-        self.assertEqual('c:\\first\\second\\third\\fifth', ph.root, 'set absolute final folder fail')
+        pth = os.path.join(self.prefix, 'first', 'second', 'third', 'fifth')
+        self.assertEqual(pth, ph.root, 'set absolute final folder fail')
 
         ph = PathHolder(self.fake_relative_path)
         ph.setFinalFolder('fifth')
-        self.assertEqual('..\\fifth', ph.relative_root, 'set relative final folder fail')
+        self.assertEqual(os.path.join('..', 'fifth'), ph.relative_root, 'set relative final folder fail')
 
     def test_absolutePath(self):
         '''Test that the absolute path is returned correctly.
@@ -71,7 +77,8 @@ class PathHolderTests(unittest.TestCase):
 
         ph = PathHolder(self.fake_relative_path, self.fake_root)
         q = ph.absolutePath()
-        self.assertEqual('c:\\some\\fake\\root\\TuflowFile.txt', ph.absolutePath(), 'absolutePath() with root and relative root fail')
+        pth = os.path.join(self.prefix, 'some', 'fake', 'root', 'TuflowFile.txt')
+        self.assertEqual(pth, ph.absolutePath(), 'absolutePath() with root and relative root fail')
 
     def test_getDirectory(self):
         '''Check that the function returns the directory properly.

--- a/tests/test_tuflowfactory.py
+++ b/tests/test_tuflowfactory.py
@@ -16,7 +16,7 @@ class TuflowFilePartTests(unittest.TestCase):
         """Setup and global variables."""
         self.prefix = '/'
         if os.name != 'posix':
-            self.prefix = 'c:'
+            self.prefix = 'c:' + os.sep
         self.fake_root = os.path.join(self.prefix, 'path', 'to', 'fake')
         main_file = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                            'comment': None, 'model_type': 'TCF',

--- a/tests/test_tuflowfactory.py
+++ b/tests/test_tuflowfactory.py
@@ -163,7 +163,7 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 
-        line = "Write Check Files == {}".format(os.path.join('..', 'checks'))
+        line = "Write Check Files == {}".format(os.path.join('..', 'checks') + os.sep)
         data = f.TuflowFactory.createResultType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -171,7 +171,7 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, os.path.join('..', 'checks'))
+        self.assertEqual(data.relative_root, os.path.join('..', 'checks') + os.sep)
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 #         self.assertTrue(data.filename_is_prefix)

--- a/tests/test_tuflowfactory.py
+++ b/tests/test_tuflowfactory.py
@@ -14,7 +14,10 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def setUp(self):
         """Setup and global variables."""
-        self.fake_root = 'c:/path/to/fake/'
+        self.prefix = '/'
+        if os.name != 'posix':
+            self.prefix = 'c:'
+        self.fake_root = os.path.join(self.prefix, 'path', 'to', 'fake')
         main_file = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                            'comment': None, 'model_type': 'TCF',
                                            'root': self.fake_root})
@@ -30,11 +33,11 @@ class TuflowFilePartTests(unittest.TestCase):
         bcsource_line = "BC Event Source == evtname | evttext"
         variable_line = "Timestep == 2.5 ! A comment"
         data_line = "Read Materials File == materials.csv"
-        output_line = "Output Folder == ..\\results\\"
-        check_line = "Write Check Files == ..\\checks\\"
+        output_line = "Output Folder == {}".format(os.path.join('..', 'results'))
+        check_line = "Write Check Files == {}".format(os.path.join('..', 'checks'))
         log_line = "Log Folder == log"
-        gis_line = "Read GIS Z Shape == ..\gis\somefile.shp"
-        model_line = "Geometry Control File == ..\\model\\tgcfile.tgc"
+        gis_line = "Read GIS Z Shape == {}".format(os.path.join('..', 'gis', 'somefile.shp'))
+        model_line = "Geometry Control File == {}".format(os.path.join('..', 'model', 'tgcfile.tgc'))
 
         self.assertIsInstance(f.TuflowFactory.getTuflowPart(scen_line, self.parent)[0], TuflowModelVariable)
         self.assertIsInstance(f.TuflowFactory.getTuflowPart(event_line, self.parent)[0], TuflowModelVariable)
@@ -148,7 +151,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_createResultType(self):
         """Test construction of ResultFile type."""
-        line = "Output Folder == ..\\results\\"
+        line = "Output Folder == {}".format(os.path.join('..', 'results'))
         data = f.TuflowFactory.createResultType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -156,11 +159,11 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, '..\\results\\')
+        self.assertEqual(data.relative_root, os.path.join('..', 'results') + os.sep)
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 
-        line = "Write Check Files == ..\\checks\\"
+        line = "Write Check Files == {}".format(os.path.join('..', 'checks'))
         data = f.TuflowFactory.createResultType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -168,7 +171,7 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, '..\\checks\\')
+        self.assertEqual(data.relative_root, os.path.join('..', 'checks'))
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 #         self.assertTrue(data.filename_is_prefix)
@@ -181,46 +184,46 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'result')
         self.assertEqual(data.filename, '')
         self.assertEqual(data.extension, '')
-        self.assertEqual(data.relative_root, 'log\\')
+        self.assertEqual(data.relative_root, 'log' + os.sep)
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), '')
 
     def test_createGisType(self):
         """Test construction of GisFile type."""
-        line = "Read GIS Z Shape == ..\gis\somefile.shp"
+        line = "Read GIS Z Shape == {}".format(os.path.join('..', 'gis', 'somefile.shp'))
         data = f.TuflowFactory.createGisType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'shp')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, os.path.join('..', 'gis'))
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.shp')
         self.assertEqual(data.gis_type, 'shp')
         self.assertTupleEqual(('shp', 'shx', 'dbf'), data.all_types)
 
-        line = "Read GIS Z Shape == ..\gis\somefile.mif"
+        line = "Read GIS Z Shape == {}".format(os.path.join('..', 'gis', 'somefile.mif'))
         data = f.TuflowFactory.createGisType(line, self.parent)[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'mif')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, os.path.join('..', 'gis'))
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.mif')
         self.assertEqual(data.gis_type, 'mi')
         self.assertTupleEqual(('mif', 'mid'), data.all_types)
 
-        line = "Read GIS Z Shape == ..\gis\somefile"
+        line = "Read GIS Z Shape == {}".format(os.path.join('..', 'gis', 'somefile'))
         data = f.TuflowFactory.createGisType(line, self.parent, test='mif')[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
         self.assertIsInstance(data, GisFile)
         self.assertEqual(data.filename, 'somefile')
         self.assertEqual(data.extension, 'mif')
-        self.assertEqual(data.relative_root, '..\gis')
+        self.assertEqual(data.relative_root, os.path.join('..', 'gis'))
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'somefile.mif')
         self.assertEqual(data.gis_type, 'mi')
@@ -228,7 +231,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_createModelType(self):
         """Test construction of ModelFile type."""
-        line = "Geometry Control File == ..\\model\\tgcfile.tgc"
+        line = "Geometry Control File == {}".format(os.path.join('..', 'model', 'tgcfile.tgc'))
         data = f.TuflowFactory.createModelType(line, self.parent, model_type='TGC')[0]
         self.assertIsInstance(data, TuflowPart)
         self.assertIsInstance(data, TuflowFile)
@@ -236,13 +239,17 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(data.obj_type, 'model')
         self.assertEqual(data.filename, 'tgcfile')
         self.assertEqual(data.extension, 'tgc')
-        self.assertEqual(data.relative_root, '..\model')
+        self.assertEqual(data.relative_root, os.path.join('..', 'model'))
         self.assertEqual(data.root, self.fake_root)
         self.assertEqual(data.filenameAndExtension(), 'tgcfile.tgc')
         self.assertEqual(data.model_type, 'TGC')
 
     def test_createGisTypeWithPipes(self):
-        line = "Read GIS Z Shape == gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
+        line = "Read GIS Z Shape == {} | {} | {}".format(
+            os.path.join('gis', 'somefile_R.shp'),
+            os.path.join('gis', 'somefile_L.shp'),
+            os.path.join('gis', 'somefile_P.shp')
+        )
         data = f.TuflowFactory.createGisType(line, self.parent)
         self.assertEqual(len(data), 3)
 
@@ -266,9 +273,12 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_partsFromPipedFiles(self):
         """Check partsFromPipedFiles."""
-#         line = "Read GIS Z Shape == gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
         vars = {}
-        vars['path'] = "gis\somefile_R.shp | gis\\somefile_L.shp | gis\\somefile_P.shp"
+        vars['path'] = "{} | {} | {}".format(
+            os.path.join('gis', 'somefile_R.shp'),
+            os.path.join('gis', 'somefile_L.shp'),
+            os.path.join('gis', 'somefile_P.shp'),
+        )
         vars['command'] = 'Read GIS Z Shape'
         vars['comment'] = ''
         vars['root'] = self.fake_root
@@ -295,9 +305,9 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_assignSiblings(self):
         """Check that sibling assignments are correct."""
-        line1 = "Read GIS Z Shape == gis\somefile_R.shp"
-        line2 = "Read GIS Z Shape == gis\\somefile_L.shp"
-        line3 = "Read GIS Z Shape == gis\\somefile_P.shp"
+        line1 = "Read GIS Z Shape == {}".format(os.path.join('gis', 'somefile_R.shp'))
+        line2 = "Read GIS Z Shape == {}".format(os.path.join('gis', 'somefile_L.shp'))
+        line3 = "Read GIS Z Shape == {}".format(os.path.join('gis', 'somefile_R.shp'))
         gis1 = f.TuflowFactory.createGisType(line1, self.parent)[0]
         gis2 = f.TuflowFactory.createGisType(line2, self.parent)[0]
         gis3 = f.TuflowFactory.createGisType(line3, self.parent)[0]
@@ -372,38 +382,50 @@ class TuflowFilePartTests(unittest.TestCase):
         """
 
         result_vars = {
-            'command': 'Output Folder', 'comment': '', 'path': '..\\results',
+            'command': 'Output Folder',
+            'comment': '',
+            'path': os.path.join('..', 'results'),
             'root': self.fake_root
         }
         rpart = ResultFile(self.parent, **result_vars)
         rpart = f.resolveResult(rpart)
         result_vars2 = {
-            'command': 'Output Folder', 'comment': '', 'path': '..\\results\\',
+            'command': 'Output Folder',
+            'comment': '',
+            'path': os.path.join('..', 'results') + os.sep,
             'root': self.fake_root
         }
         rpart2 = ResultFile(self.parent, **result_vars2)
         rpart2 = f.resolveResult(rpart2)
         result_vars3 = {
-            'command': 'Output Folder', 'comment': '', 'path': 'c:\\path\\to\\results\\',
+            'command': 'Output Folder',
+            'comment': '',
+            'path': os.path.join(self.prefix, 'path', 'to', 'results') + os.sep,
             'root': self.fake_root
         }
         rpart3 = ResultFile(self.parent, **result_vars3)
         rpart3 = f.resolveResult(rpart3)
 
         log_vars = {
-            'command': 'Log Folder', 'comment': '', 'path': 'log',
+            'command': 'Log Folder',
+            'comment': '',
+            'path': 'log',
             'root': self.fake_root
         }
         lpart = ResultFile(self.parent, **log_vars)
         lpart = f.resolveResult(lpart)
         log_vars2 = {
-            'command': 'Log Folder', 'comment': '', 'path': 'log\\',
+            'command': 'Log Folder',
+            'comment': '',
+            'path': 'log' + os.sep,
             'root': self.fake_root
         }
         lpart2 = ResultFile(self.parent, **log_vars2)
         lpart2 = f.resolveResult(lpart2)
         log_vars3 = {
-            'command': 'Log Folder', 'comment': '', 'path': 'c:\\path\\to\\log',
+            'command': 'Log Folder',
+            'comment': '',
+            'path': os.path.join(self.prefix, 'path', 'to', 'log'),
             'root': self.fake_root
         }
         lpart3 = ResultFile(self.parent, **log_vars3)
@@ -423,11 +445,12 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(lpart2.filename, '')
         self.assertEqual(lpart3.filename, '')
 
-        self.assertEqual(rpart.relative_root, '..\\results\\')
-        self.assertEqual(rpart2.relative_root, '..\\results\\')
+        pth = os.path.join('..', 'results') + os.sep
+        self.assertEqual(rpart.relative_root, pth)
+        self.assertEqual(rpart2.relative_root, pth)
         self.assertEqual(rpart3.relative_root, '')
-        self.assertEqual(lpart.relative_root, 'log\\')
-        self.assertEqual(lpart2.relative_root, 'log\\')
+        self.assertEqual(lpart.relative_root, 'log' + os.sep)
+        self.assertEqual(lpart2.relative_root, 'log' + os.sep)
         self.assertEqual(lpart3.relative_root, '')
 
         self.assertFalse(rpart.filename_is_prefix)
@@ -443,25 +466,33 @@ class TuflowFilePartTests(unittest.TestCase):
         Test the resolveResult function with Write Check Files command.
         """
         check_vars = {
-            'command': 'Write Check Files', 'comment': '', 'path': '..\\check',
+            'command': 'Write Check Files',
+            'comment': '',
+            'path': os.path.join('..', 'check'),
             'root': self.fake_root
         }
         cpart = ResultFile(self.parent, **check_vars)
         cpart = f.resolveResult(cpart)
         check_vars2 = {
-            'command': 'Write Check Files', 'comment': '', 'path': '..\\check\\',
+            'command': 'Write Check Files',
+            'comment': '',
+            'path': os.path.join('..', 'check') + os.sep,
             'root': self.fake_root
         }
         cpart2 = ResultFile(self.parent, **check_vars2)
         cpart2 = f.resolveResult(cpart2)
         check_vars3 = {
-            'command': 'Write Check Files', 'comment': '', 'path': 'c:\\path\\to\\check',
+            'command': 'Write Check Files',
+            'comment': '',
+            'path': os.path.join(self.prefix, 'path', 'to', 'check'),
             'root': self.fake_root
         }
         cpart3 = ResultFile(self.parent, **check_vars3)
         cpart3 = f.resolveResult(cpart3)
         check_vars4 = {
-            'command': 'Write Check Files', 'comment': '', 'path': 'c:\\path\\to\\check\\',
+            'command': 'Write Check Files',
+            'comment': '',
+            'path': os.path.join(self.prefix, 'path', 'to', 'check') + os.sep,
             'root': self.fake_root
         }
         cpart4 = ResultFile(self.parent, **check_vars4)
@@ -477,8 +508,8 @@ class TuflowFilePartTests(unittest.TestCase):
         self.assertEqual(cpart3.filename, 'check')
         self.assertEqual(cpart4.filename, '')
 
-        self.assertEqual(cpart.relative_root, '..\\')
-        self.assertEqual(cpart2.relative_root, '..\\check\\')
+        self.assertEqual(cpart.relative_root, '..' + os.sep)
+        self.assertEqual(cpart2.relative_root, os.path.join('..', 'check') + os.sep)
         self.assertEqual(cpart3.relative_root, '')
         self.assertEqual(cpart4.relative_root, '')
 

--- a/tests/test_tuflowfilepart.py
+++ b/tests/test_tuflowfilepart.py
@@ -19,7 +19,7 @@ class TuflowFilePartTests(unittest.TestCase):
 
         Tests within test_tuflowfactor.py provide decent coverage of creating
         new instances of specific TuflowPart's and checking that they have
-        been instanciated properly. If you need to add tests to check that 
+        been instanciated properly. If you need to add tests to check that
         they have been created properly they should probably go in the factory
         tests.
     '''
@@ -27,30 +27,43 @@ class TuflowFilePartTests(unittest.TestCase):
     def setUp(self):
 
         # Setup a main .tcf file
-        self.fake_root = 'c:/path/to/fake/'
+        self.prefix = '/'
+        if os.name != 'posix':
+            self.prefix = 'c:'
+        self.fake_root = os.path.join(self.prefix, 'path', 'to', 'fake')
         self.tcf = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                           'comment': None, 'model_type': 'TCF',
                                           'root': self.fake_root})
 
         # Setup a tgc file with tcf parent
-        tgc_line = "Geometry Control File == ..\\model\\tgcfile.tgc ! A tgc comment"
+        tgc_line = "Geometry Control File == {} ! A tgc comment".format(
+            os.path.join('..', 'model', 'tgcfile.tgc')
+        )
         self.tgc = f.TuflowFactory.getTuflowPart(tgc_line, self.tcf)[0]
 
         # Setup a gis file with tgc parent
-        gis_line = "Read Gis Z Shape == gis\\gisfile.shp ! A gis comment"
+        gis_line = "Read Gis Z Shape == {} ! A gis comment".format(
+            os.path.join('gis', 'gisfile.shp')
+        )
         self.gis = f.TuflowFactory.getTuflowPart(gis_line, self.tgc)[0]
         var_line = "Timestep == 2 ! A var comment"
         self.var = f.TuflowFactory.getTuflowPart(var_line, self.tgc)[0]
-        gis_line2 = "Read Gis Z Shape == gis\\gisfile2.shp ! A gis 2 comment"
+        gis_line2 = "Read Gis Z Shape == {} ! A gis 2 comment".format(
+            os.path.join('gis', 'gisfile2.shp')
+        )
         self.gis2 = f.TuflowFactory.getTuflowPart(gis_line2, self.tgc)[0]
 
         # For the evt testing stuff
-        line_evt = "Read Gis Z Shape == gis\\gisfile_evt.shp ! A gis 3 comment"
+        line_evt = "Read Gis Z Shape == {} ! A gis 3 comment".format(
+            os.path.join('gis', 'gisfile_evt.shp')
+        )
         self.gis_evt = f.TuflowFactory.getTuflowPart(line_evt, self.tgc)[0]
         linevar_evt = "Timestep == 6 ! A var evt comment"
         self.var_evt = f.TuflowFactory.getTuflowPart(linevar_evt, self.tgc)[0]
         # For the scenario testing stuff
-        line_scen = "Read Gis Z Shape == gis\\gisfile_evt.shp ! A gis 3 comment"
+        line_scen = "Read Gis Z Shape == {} ! A gis 3 comment".format(
+            os.path.join('gis', 'gisfile_evt.shp')
+        )
         self.gis_scen = f.TuflowFactory.getTuflowPart(line_scen, self.tgc)[0]
         linevar_scen = "Timestep == 6 ! A var scen comment"
         self.var_scen = f.TuflowFactory.getTuflowPart(linevar_scen, self.tgc)[0]
@@ -130,7 +143,8 @@ class TuflowFilePartTests(unittest.TestCase):
             's1': 'scen1', 'size': '10', 'e1': 'event1', 'anothervar': '2.5'
         }
         path = vardata.absolutePath(user_vars=user_vars)
-        self.assertEqual('c:\\path\\to\\model\\Materials_scen1.tmf', path)
+        pth = os.path.join(self.prefix, 'path', 'to', 'model', 'Materials_scen1.tmf')
+        self.assertEqual(pth, path)
         var = TuflowPart.resolvePlaceholder(varvar.variable, user_vars)
         var2 = varvar.resolvedVariable(user_vars)
         var3 = varvar.resolvePlaceholder(varvar.variable, user_vars=user_vars)
@@ -140,8 +154,8 @@ class TuflowFilePartTests(unittest.TestCase):
 
     def test_TFabsolutePath(self):
         """Test return value of absolutePath in TuflowFile."""
-        path1 = 'c:\\path\\to\\model\\tgcfile.tgc'
-        path2 = 'c:\\path\\to\\model\\gis\\gisfile.shp'
+        path1 = os.path.join(self.prefix, 'path', 'to', 'model', 'tgcfile.tgc')
+        path2 = os.path.join(self.prefix, 'path', 'to', 'model', 'gis', 'gisfile.shp')
         self.assertEqual(path1, self.tgc.absolutePath())
         self.assertEqual(path2, self.gis.absolutePath())
 
@@ -151,15 +165,17 @@ class TuflowFilePartTests(unittest.TestCase):
         This will return the same as absolutePath if there is only one associated
         file extension. Otherwise it will return one path for each type.
         """
-        paths = ['c:\\path\\to\\model\\gis\\gisfile.shp',
-                 'c:\\path\\to\\model\\gis\\gisfile.shx',
-                 'c:\\path\\to\\model\\gis\\gisfile.dbf']
+        paths = [
+            os.path.join(self.prefix, 'path', 'to', 'model', 'gis', 'gisfile.shp'),
+            os.path.join(self.prefix, 'path', 'to', 'model', 'gis', 'gisfile.shx'),
+            os.path.join(self.prefix, 'path', 'to', 'model', 'gis', 'gisfile.dbf')]
         self.assertListEqual(paths, self.gis.absolutePathAllTypes())
 
     def test_TFrelativePath(self):
         """Test return value of relativePaths in TuflowFile."""
-        path1 = ['..\\model']
-        path2 = ['..\\model', 'gis']
+        relpath = os.path.join('..', 'model')
+        path1 = [relpath]
+        path2 = [relpath, 'gis']
         self.assertListEqual(path1, self.tgc.getRelativeRoots([]))
         self.assertListEqual(path2, self.gis.getRelativeRoots([]))
 

--- a/tests/test_tuflowfilepart.py
+++ b/tests/test_tuflowfilepart.py
@@ -29,7 +29,7 @@ class TuflowFilePartTests(unittest.TestCase):
         # Setup a main .tcf file
         self.prefix = '/'
         if os.name != 'posix':
-            self.prefix = 'c:'
+            self.prefix = 'c:' + os.sep
         self.fake_root = os.path.join(self.prefix, 'path', 'to', 'fake')
         self.tcf = tfp.ModelFile(None, **{'path': 'tcffile.tcf', 'command': None,
                                           'comment': None, 'model_type': 'TCF',


### PR DESCRIPTION
These changes get all tests passing on windows on linux. 
The changes are mostly centered on making paths in the unit tests platform agnostic; there may be further work to do around `PathHolder` in general